### PR TITLE
Us30

### DIFF
--- a/app/controllers/merchant/dashboard_controller.rb
+++ b/app/controllers/merchant/dashboard_controller.rb
@@ -5,6 +5,20 @@ class Merchant::DashboardController < ApplicationController
 
   end
 
+  def fulfill_item
+    item_order = ItemOrder.where('item_id=?', params[:item_id]).where('order_id=?', params[:order_id]).first
+    item_order.status = "Fulfilled"
+    item_order.save
+    order = Order.find(params[:order_id])
+    all_order_items = ItemOrder.where('order_id=?', params[:order_id])
+    fulfilled = all_order_items.all? {|item| item.status == "Fulfilled"}
+    if fulfilled
+      order.status = "Packaged"
+      order.save
+    end
+    redirect_to request.referrer
+  end
+
   def require_merchant
     render file: "/public/404" unless current_merchant?
   end

--- a/app/controllers/user_orders_controller.rb
+++ b/app/controllers/user_orders_controller.rb
@@ -9,6 +9,19 @@ class UserOrdersController < ApplicationController
     @items = item_orders.map do |item_order|
       Item.find(item_order.item_id)
     end
+  end
 
+  def cancel_order
+    order = Order.find(params[:order_id])
+    order.status = "Cancelled"
+    order.save
+
+    item_orders = order.item_orders
+    item_orders.each do |item_order|
+      item_order.status = "Unfulfilled"
+      item_order.save
+    end
+    redirect_to "/profile"
+    flash[:alert]="Order successfully cancelled"
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -15,11 +15,6 @@ class Order < ApplicationRecord
     item_orders.sum('quantity')
   end
 
-  def status
-    return "Packaged" if self.item_orders.where('status = ?', 'Pending').count == 0
-    "Pending"
-  end
-
   def item_quantity(item)
     ItemOrder.where("order_id = ?", self.id).where("item_id = ?", item.id).first.quantity
   end

--- a/app/views/user_orders/show.html.erb
+++ b/app/views/user_orders/show.html.erb
@@ -1,12 +1,15 @@
 <h2>Order Details</h2>
 <p>
-  Order ID: <%= link_to "#{@order.id}", "orders/#{@order.id}" %>
+  Order ID: <%= @order.id %>
   <br>
   Created at: <%= @order.created_at %>
   Updated at: <%= @order.updated_at %>
   Order Status: <%= @order.status %>
   Total quantity of items: <%= @order.total_quantity %>
   Grand total: <%= @order.grand_total %>
+</p>
+<p>
+<%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %>
 </p>
 <% @items.each do |item| %>
   <tr id= "item-<%=item.id%>">
@@ -17,6 +20,9 @@
       Item quantity: <%= @order.item_quantity(item) %>
       Item price: <%= number_to_currency(item.price) %>
       Item subtotal: <%= number_to_currency(@order.item_subtotal(item)) %>
+      <% if current_merchant? %>
+      <%= link_to "Fulfill Item", "/merchant/orders/#{@order.id}?item_id=#{item.id}", method: :patch %>
+      <% end %>
     </p>
   </tr>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,18 +12,11 @@ Rails.application.routes.draw do
 
   get '/profile/orders', to: 'user_orders#index'
   get '/profile/orders/:order_id', to: 'user_orders#show'
+  patch '/profile/orders/:order_id', to: 'user_orders#cancel_order'
 
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   get '/logout', to: 'sessions#destroy'
-
-  namespace :merchant do
-    get '/dashboard', to: 'dashboard#index'
-  end
-
-  namespace :admin do
-    get '/dashboard', to: 'dashboard#index'
-  end
 
   get    "/merchants",          to: "merchants#index"
   get    "/merchants/new",      to: "merchants#new"
@@ -65,10 +58,13 @@ Rails.application.routes.draw do
 
   namespace :merchant do
     get '/', to: 'dashboard#index'
+    get '/dashboard', to: 'dashboard#index'
+    patch '/orders/:order_id', to: 'dashboard#fulfill_item'
   end
 
   namespace :admin do
     get '/', to: 'dashboard#index'
     get '/users', to: 'users#index'
+    get '/dashboard', to: 'dashboard#index'
   end
 end

--- a/spec/features/orders/status_spec.rb
+++ b/spec/features/orders/status_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe("Order's status") do
+  it 'changes from pending to packaged when all items are fulfilled' do
+    bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    tire = bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+    bike_tool = bike_shop.items.create(name: "Bike Tool", description: "Make it tight!", price: 30, image: "https://www.rei.com/media/product/718804", inventory: 100)
+
+    dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+    pull_toy = dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
+    kong = dog_shop.items.create(name: "Kong", description: "Tasty treat!", price: 10, image: "https://images-na.ssl-images-amazon.com/images/I/719dcnCnHfL._AC_SL1500_.jpg", inventory: 50)
+
+    order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+    order_1.item_orders.create!(item: pull_toy, price: pull_toy.price, quantity: 4, status: 'Fulfilled')
+    order_1.item_orders.create!(item: tire, price: tire.price, quantity: 6, status: 'Fulfilled')
+    order_1.item_orders.create!(item: kong, price: kong.price, quantity: 4, status: 'Fulfilled')
+    order_1.item_orders.create!(item: bike_tool, price: bike_tool.price, quantity: 3)
+    merchant = User.create!(name: 'Jim', address: '456 Blah Blah Blvd', city: 'Denver', state: 'CO', zip: '12345', email: 'regularjim@me.com', password: 'alsosecret', role: 1)
+
+    visit '/login'
+    fill_in :email, with: merchant.email
+    fill_in :password, with: merchant.password
+    click_button "Log In"
+
+    expect(order_1.status).to eq('Pending')
+
+    visit "/profile/orders/#{order_1.id}"
+
+    within "#item-#{bike_tool.id}" do
+      click_link "Fulfill Item"
+    end
+
+    order_1.reload
+
+    expect(order_1.status).to eq('Packaged')
+  end
+end

--- a/spec/features/users/orders/show_spec.rb
+++ b/spec/features/users/orders/show_spec.rb
@@ -35,4 +35,51 @@ RSpec.describe("User Order's Show Page") do
       expect(page).to have_content("Item subtotal: $400")
     end
   end
+
+  it "I see a button allowing user to cancel the order" do
+    user_1 = User.create!(name: 'Bob', address: '123 Who Cares Ln', city: 'Denver', state: 'CO', zip: '12345', email: 'regularbob@me.com', password: 'secret')
+    visit '/login'
+    fill_in :email, with: user_1.email
+    fill_in :password, with: user_1.password
+    click_button "Log In"
+
+    bike_shop = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    tire = bike_shop.items.create!(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+
+    dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+    pull_toy = dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
+
+    order_1 = Order.create!(name: 'Bob', address: '123 Who Cares Ln', city: 'Denver', state: 'CO', zip: '12345')
+    order_2 = Order.create!(name: 'Joe', address: '123 Who Cares Ln', city: 'Denver', state: 'CO', zip: '12345')
+    item_order_1 = order_1.item_orders.create!(item: tire, price: tire.price, quantity: 4)
+    order_1.item_orders.create!(item: pull_toy, price: pull_toy.price, quantity: 3)
+    order_2.item_orders.create!(item: pull_toy, price: pull_toy.price, quantity: 2)
+
+    user_order_1 = user_1.user_orders.create!(order: order_1, user: user_1)
+    user_1.user_orders.create!(order: order_2, user: user_1)
+
+    visit "/profile/orders/#{order_1.id}"
+
+    expect(item_order_1.status).to eq("Pending")
+    expect(page).to have_button("Cancel Order")
+    expect(page).to have_content("Order Status: Pending")
+    expect(page).to have_content(order_1.status)
+
+    click_button "Cancel Order"
+
+    expect(current_path).to eq("/profile")
+
+    order_1.reload
+    item_order_1.reload
+
+    expect(page).to have_content("Order successfully cancelled")
+    expect(item_order_1.status).to eq("Unfulfilled")
+    expect(order_1.status).to eq("Cancelled")
+
+    visit "/profile/orders"
+
+    within "#order-#{order_1.id}" do
+      expect(page).to have_content("Order Status: Cancelled")
+    end
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -32,28 +32,5 @@ describe Order, type: :model do
     it '#grand_total' do
       expect(@order_1.grand_total).to eq(230)
     end
-
-    it 'changes from pending to packaged when all items are fulfilled' do
-      bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      tire = bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      bike_tool = bike_shop.items.create(name: "Bike Tool", description: "Make it tight!", price: 30, image: "https://www.rei.com/media/product/718804", inventory: 100)
-
-      dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
-      pull_toy = dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
-      kong = dog_shop.items.create(name: "Kong", description: "Tasty treat!", price: 10, image: "https://images-na.ssl-images-amazon.com/images/I/719dcnCnHfL._AC_SL1500_.jpg", inventory: 50)
-
-      order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
-      order_1.item_orders.create!(item: pull_toy, price: pull_toy.price, quantity: 4, status: 'Fulfilled')
-      order_1.item_orders.create!(item: tire, price: tire.price, quantity: 6, status: 'Fulfilled')
-      order_1.item_orders.create!(item: kong, price: kong.price, quantity: 4, status: 'Fulfilled')
-      bike_tool = order_1.item_orders.create!(item: bike_tool, price: bike_tool.price, quantity: 3)
-
-      expect(order_1.status).to eq('Pending')
-
-      bike_tool[:status] = 'Fulfilled'
-      bike_tool.save
-
-      expect(order_1.status).to eq('Packaged')
-    end
   end
 end


### PR DESCRIPTION
I see a button or link to cancel the order, I click the cancel button for an order, the following happens:
- Each row in the "order items" table is given a status of "unfulfilled"
- The order itself is given a status of "cancelled"
- I am returned to my profile page
- I see a flash message telling me the order is now cancelled
- And I see that this order now has an updated status of "cancelled"

Still need to complete functionality:
- Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.