### PR TITLE
US38

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,16 @@
+class Admin::MerchantsController < ApplicationController
+
+  def index
+    @merchants = Merchant.all
+  end
+
+  def enable_disable
+    merchant = Merchant.find(params[:merchant_id])
+    if merchant.enabled?
+      merchant.enabled = false
+      merchant.save
+      redirect_to request.referrer
+      flash[:notice] = "#{merchant.name} has been disabled"
+    end
+  end
+end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,0 +1,17 @@
+<h1 align = "center">Merchants</h1>
+<section class = "grid-container">
+  <p>
+    <% @merchants.each do |merchant|%>
+      <tr id="merchant-<%= merchant.id %>">
+        <section class = "grid-item">
+          <h2><%= merchant.name %></h2> <br>
+          <% if merchant.enabled? %>
+            <%= "Status: Enabled" %>
+            <%= button_to "Disable", "merchants/#{merchant.id}", method: :patch %>
+            <% else %>
+            <%= "Status: Disabled" %>
+          <% end %>
+        </section>
+      </tr>
+    <% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,5 +63,7 @@ Rails.application.routes.draw do
     get '/users', to: 'users#index'
     get '/dashboard', to: 'dashboard#index'
     patch '/orders/:order_id', to: 'dashboard#ship_order'
+    get '/merchants', to: 'merchants#index'
+    patch '/merchants/:merchant_id', to: 'merchants#enable_disable'
   end
 end

--- a/db/migrate/20200728025016_add_enabled_to_merchants.rb
+++ b/db/migrate/20200728025016_add_enabled_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddEnabledToMerchants < ActiveRecord::Migration[5.1]
+  def change
+    add_column :merchants, :enabled, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200727211617) do
+ActiveRecord::Schema.define(version: 20200728025016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20200727211617) do
     t.integer "zip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "enabled", default: true
   end
 
   create_table "orders", force: :cascade do |t|

--- a/spec/features/admin/merchants_spec.rb
+++ b/spec/features/admin/merchants_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe "As an Admin" do
+  describe "When I visit the admin's merchant index page" do
+    it "I can disable a merchants account and I see a flash message that the account is now disabled" do
+
+      tire_shop = Merchant.create!(name: 'Rubber, Meet Road', address: '621 Knox St', city: 'Denver', state: 'CO', zip: 80209)
+      pot_shop = Merchant.create!(name: 'Green Thumb', address: '420 High St', city: 'Denver', state: 'CO', zip: 80207)
+      bike_shop = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+
+      admin = User.create!(name: 'Bob', address: '123 Who Cares Ln', city: 'Denver', state: 'CO', zip: '12345', email: 'regularbob@me.com', password: 'secret', role: 2)
+      visit '/login'
+      fill_in :email, with: admin.email
+      fill_in :password, with: admin.password
+      click_button "Log In"
+
+      visit '/admin/merchants'
+
+      within "#merchant-#{tire_shop.id}" do
+        expect(page).to have_content("Status: Enabled")
+        expect(page).to have_button("Disable")
+        click_button "Disable"
+      end
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to have_content("#{tire_shop.name} has been disabled")
+
+      within "#merchant-#{tire_shop.id}" do
+        expect(page).to_not have_button("Disable")
+        expect(page).to have_content("Status: Disabled")
+      end
+    end
+  end
+end

--- a/true
+++ b/true
@@ -1,0 +1,2 @@
+      invoke  active_record
+      create    db/migrate/20200728024717_add_enabled_to_merchants.rb


### PR DESCRIPTION
As an admin when I visit the admin's merchant index page:
I see a "disable" button next to any merchants who are not yet disabled when I click on the "disable" button, I am returned to the admin's merchant index page where I see that the merchant's account is now disabled and I see a flash message that the merchant's account is now disabled.