### PR TITLE
US40

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -15,6 +15,10 @@ class Admin::MerchantsController < ApplicationController
       end
       redirect_to request.referrer
       flash[:notice] = "#{merchant.name} has been disabled"
+    else
+      merchant.toggle!(:enabled)
+      redirect_to request.referrer
+      flash[:notice] = "#{merchant.name} has been enabled"
     end
   end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -5,12 +5,13 @@
       <tr id="merchant-<%= merchant.id %>">
         <section class = "grid-item">
           <h2><%= merchant.name %></h2> <br>
-          <% if merchant.enabled? %>
-            <%= "Status: Enabled" %>
-            <%= button_to "Disable", "merchants/#{merchant.id}", method: :patch %>
-            <% else %>
-            <%= "Status: Disabled" %>
-          <% end %>
+            <% if merchant.enabled? %>
+              <%= "Status: Enabled" %>
+              <%= button_to "Disable", "merchants/#{merchant.id}", method: :patch %>
+              <% else %>
+              <%= "Status: Disabled" %>
+              <%= button_to "Enable", "merchants/#{merchant.id}", method: :patch %>
+            <% end %>
         </section>
       </tr>
     <% end %>

--- a/spec/features/admin/merchants_spec.rb
+++ b/spec/features/admin/merchants_spec.rb
@@ -67,5 +67,40 @@ RSpec.describe "As an Admin" do
       expect(bike_pump.active?).to eq(false)
       expect(bike_chain.active?).to eq(false)
     end
+
+    it "I can enable a merchants account and I see a flash message that the account is now enabled" do
+
+      tire_shop = Merchant.create!(name: 'Rubber, Meet Road', address: '621 Knox St', city: 'Denver', state: 'CO', zip: 80209)
+
+      admin = User.create!(name: 'Bob', address: '123 Who Cares Ln', city: 'Denver', state: 'CO', zip: '12345', email: 'regularbob@me.com', password: 'secret', role: 2)
+
+      visit '/login'
+      fill_in :email, with: admin.email
+      fill_in :password, with: admin.password
+      click_button "Log In"
+
+      visit '/admin/merchants'
+
+      within "#merchant-#{tire_shop.id}" do
+        expect(page).to have_content("Status: Enabled")
+        expect(page).to have_button("Disable")
+        click_button "Disable"
+      end
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to have_content("#{tire_shop.name} has been disabled")
+
+      within "#merchant-#{tire_shop.id}" do
+        expect(page).to have_content("Status: Disabled")
+        expect(page).to have_button("Enable")
+        click_button "Enable"
+      end
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to have_content("#{tire_shop.name} has been enabled")
+
+      within "#merchant-#{tire_shop.id}" do
+        expect(page).to have_button("Disable")
+        expect(page).to have_content("Status: Enabled")
+      end
+    end
   end
 end


### PR DESCRIPTION
As an admin when I visit the merchant index page, I see an "enable" button next to any merchants whose accounts are disabled and when I click on the "enable" button I am returned to the admin's merchant index page where I see that the merchant's account is now enabled and I see a flash message that the merchant's account is now enabled.